### PR TITLE
Add new event hook for starting a new level: "ingameNewScene"

### DIFF
--- a/automation/abc/newScene.abc
+++ b/automation/abc/newScene.abc
@@ -1,0 +1,4 @@
+     getlex              QName(PackageNamespace("com.giab.games.gcfw"), "GV")
+     getproperty         QName(PackageNamespace(""), "main")
+     getproperty         QName(PackageNamespace(""), "bezel")
+     callpropvoid        QName(PackageNamespace(""), "ingameNewScene"), 0

--- a/automation/actions.json
+++ b/automation/actions.json
@@ -104,5 +104,17 @@
         "file": "renderInfoPanel.abc"
       }
     ]
+  },
+  {
+    "script": "IngameInitializer.class",
+    "file": "com/giab/games/gcfw/ingame/IngameInitializer.class.asasm",
+    "actions": [
+      {
+        "type": "insert",
+        "identifier": "monsterEggHunt",
+        "offset": "-2",
+        "file": "newScene.abc"
+      }
+    ]
   }
 ]

--- a/src/Bezel/Bezel.as
+++ b/src/Bezel/Bezel.as
@@ -220,5 +220,10 @@ package Bezel
 			mods = new Array();
 			loadMods();
 		}
+
+		public function ingameNewScene(): void
+		{
+			dispatchEvent(new IngameNewSceneEvent(BezelEvent.INGAME_NEW_SCENE));
+		}
 	}
 }

--- a/src/Bezel/BezelEvent.as
+++ b/src/Bezel/BezelEvent.as
@@ -12,6 +12,7 @@ package Bezel
 		public static const INGAME_PRE_RENDER_INFO_PANEL:String = "ingamePreRenderInfoPanel";
 		public static const INGAME_CLICK_ON_SCENE:String = "ingameClickOnScene";
 		public static const INGAME_RIGHT_CLICK_ON_SCENE:String = "ingameRightClickOnScene";
+		public static const INGAME_NEW_SCENE:String = "ingameNewScene";
 		
 		public function BezelEvent() 
 		{

--- a/src/Bezel/Events/IngameNewSceneEvent.as
+++ b/src/Bezel/Events/IngameNewSceneEvent.as
@@ -1,0 +1,17 @@
+package Bezel.Events 
+{
+	/**
+	 * ...
+	 * @author Hellrage
+	 */
+	
+	import flash.events.Event;
+	import Bezel.BezelEvent;
+	public class IngameNewSceneEvent extends Event
+	{
+		public function IngameNewSceneEvent(type:String, bubbles:Boolean=false, cancelable:Boolean=false) 
+		{
+			super(type, bubbles, cancelable);
+		}
+	}
+}

--- a/src/Bezel/Events/IngameNewSceneEvent.as
+++ b/src/Bezel/Events/IngameNewSceneEvent.as
@@ -2,7 +2,7 @@ package Bezel.Events
 {
 	/**
 	 * ...
-	 * @author Hellrage
+	 * @author piepie62
 	 */
 	
 	import flash.events.Event;


### PR DESCRIPTION
This technically does not fire at the end of the scene's creation, and is done before the addition of egg hunt eggs. However, I don't entirely feel comfortable making a supposedly-general patch skip hundreds of lines. If you'd like that to be changed, I can do it