### PR TITLE
Utilities, bugfixes, and GOG installer compatibility

### DIFF
--- a/Bezel.as3proj
+++ b/Bezel.as3proj
@@ -4,7 +4,7 @@
   <output>
     <movie outputType="Application" />
     <movie input="" />
-    <movie path="C:\Program Files (x86)\Steam\steamapps\common\GemCraft Frostborn Wrath\GemCraft Frostborn Wrath.swf" />
+    <movie path="D:\Games\Steam\steamapps\common\GemCraft Frostborn Wrath\Mods\BezelModLoader.swf" />
     <movie fps="30" />
     <movie width="800" />
     <movie height="600" />

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -1,7 +1,11 @@
-CXXFLAGS := -std=c++17
+CXXFLAGS := $(CXXFLAGS) -std=c++17 -m32
+ASFLAGS  := $(ASFLAGS) --32
 
 bezel-installer.exe: bezel-installer.o bezel-swf.o
-	$(CXX) -static -o bezel-installer.exe bezel-swf.o bezel-installer.o
+	$(CXX) $(CXXFLAGS) -static -o bezel-installer.exe bezel-swf.o bezel-installer.o
+
+bezel-installer.o: bezel-installer.cpp
+bezel-swf.o: bezel-swf.s ../obj/BezelModLoader.swf
 
 clean:
-	rm bezel-swf.o bezel-installer.o
+	rm bezel-swf.o bezel-installer.o bezel-installer.exe

--- a/installer/bezel-installer.cpp
+++ b/installer/bezel-installer.cpp
@@ -26,6 +26,12 @@ int main()
 
     const std::filesystem::path metadataFile{"META-INF/AIR/application.xml"};
     const std::filesystem::path metadataBkpFile{"META-INF/AIR/application.xml.bkp"};
+    const std::filesystem::path gcfwBkpFile{"GemCraft Frostborn Wrath Backup.swf"};
+
+    if (std::filesystem::exists(gcfwBkpFile))
+    {
+        std::filesystem::rename(gcfwBkpFile, "GemCraft Frostborn Wrath.swf");
+    }
 
     if (!std::filesystem::exists(metadataFile))
     {

--- a/installer/bezel-installer.cpp
+++ b/installer/bezel-installer.cpp
@@ -6,67 +6,115 @@
 extern unsigned char swfData[] asm("swfData");
 extern int swfSize asm("swfSize");
 
-void waitExit(const char *exitMessage, int exitCode)
+[[noreturn]] void waitExit(const char *exitMessage, int exitCode)
 {
-    printf(exitMessage);
+    printf("%s\n", exitMessage);
     if (exitCode != 0)
     {
-        printf("%i", exitCode);
+        printf("Installation failed. This should be run from your GCFW folder, findable through Steam's \"Browse Local Files\". If you are running this in the correct place, please file a bug report.\n");
+        printf("Exit code: %i (please provide this if you're making a bug report!)\n", exitCode);
     }
     char trash[2];
+    printf("Hit any key to exit");
     std::cin.read(trash, 1);
     exit(exitCode);
 }
 
 int main()
 {
-    std::error_code trashError;
+    std::error_code ec;
+
+    const std::filesystem::path metadataFile{"META-INF/AIR/application.xml"};
+    const std::filesystem::path metadataBkpFile{"META-INF/AIR/application.xml.bkp"};
+
+    if (!std::filesystem::exists(metadataFile))
+    {
+        waitExit("Metadata file does not exist.", -3);
+    }
+
+    if (!std::filesystem::exists(metadataBkpFile))
+    {
+        std::filesystem::copy_file(metadataFile, metadataBkpFile, std::filesystem::copy_options::overwrite_existing);
+    }
+
+    FILE *inFile = _wfopen(metadataFile.generic_wstring().c_str(), L"rt");
+    if (!inFile)
+    {
+        waitExit("Metadata file could not be opened for reading.", -5);
+    }
+    std::string metadata{static_cast<std::string::size_type>(std::filesystem::file_size(metadataFile)), '\0', std::allocator<char>()};
+    fread(metadata.data(), 1, metadata.size(), inFile);
+    fclose(inFile);
+
+    metadata = metadata.substr(0, metadata.find_first_of('\0'));
+
+    auto tagStart = metadata.find("<id>");
+    auto tagEnd = metadata.find("</id>");
+
+    if (tagStart == std::string::npos || tagEnd == std::string::npos)
+    {
+        waitExit("No ID within the metadata XML.", -4);
+    }
+
+    tagStart += 4;
+
+    std::string gameID = metadata.substr(tagStart, tagEnd - tagStart);
 
     std::filesystem::path appdata{getenv("APPDATA")};
     if (std::filesystem::exists(appdata))
     {
-        std::filesystem::path gcfwData = appdata / "com.giab.games.gcfw.steam" / "Local Store";
+        std::filesystem::path gcfwData = appdata / gameID / "Local Store";
         if (std::filesystem::exists(gcfwData))
         {
-            std::filesystem::remove(gcfwData / "coremods.bzl", trashError);
-            std::filesystem::remove(gcfwData / "coremods.lttc", trashError);
-            std::filesystem::remove(gcfwData / "gcfw.basasm", trashError);
-            std::filesystem::remove(gcfwData / "gcfw-clean.basasm", trashError);
+            // Intentionally ignore these errors; if they don't exist there's no issue
+            try
+            {
+                std::filesystem::remove(gcfwData / "coremods.bzl");
+                std::filesystem::remove(gcfwData / "coremods.lttc");
+                std::filesystem::remove(gcfwData / "gcfw.basasm");
+                std::filesystem::remove(gcfwData / "gcfw-clean.basasm");
+            }
+            catch (std::filesystem::filesystem_error &e)
+            {
+                waitExit("Could not remove previous Bezel's temporary files from application storage directory.", e.code().value());
+            }
         }
     }
     else
     {
-        waitExit("Could not locate %APPDATA%", -1);
+        waitExit("Could not locate %APPDATA%.", -1);
     }
 
-    std::filesystem::remove("gcfw-modded.swf", trashError);
+    std::filesystem::remove("gcfw-modded.swf", ec);
 
-    std::filesystem::path gameFile{"GemCraft Frostborn Wrath.swf"};
+    tagStart = metadata.find("<content>");
+    tagEnd = metadata.find("</content>");
 
-    try
+    if (tagStart == std::string::npos || tagEnd == std::string::npos)
     {
-        if (std::filesystem::file_size(gameFile) > 100 * 1024 * 1024)
-        {
-            std::filesystem::rename(gameFile, "GemCraft Frostborn Wrath Backup.swf");
-            FILE *out = _wfopen(gameFile.generic_wstring().c_str(), L"wb");
-            fwrite(swfData, 1, swfSize, out);
-            fclose(out);
-
-            std::filesystem::create_directory("Mods", trashError);
-
-            waitExit("Installation succeeded. Press enter to exit.", 0);
-        }
-        else
-        {
-            std::filesystem::create_directory("Mods", trashError);
-
-            waitExit("Bezel appears to already be installed. If this is not correct, please file a bug report.", -2);
-        }
+        waitExit("No SWF content tag within the metadata XML.", -6);
     }
-    catch (std::filesystem::filesystem_error &e)
+
+    tagStart += 9;
+
+    metadata.replace(metadata.cbegin() + tagStart, metadata.cbegin() + tagEnd, "Mods/BezelModLoader.swf");
+
+    const std::filesystem::path bezelFile{"Mods/BezelModLoader.swf"};
+
+    std::filesystem::create_directory("Mods", ec);
+
+    if (ec)
     {
-        waitExit("Installation failed. This should be run from your GCFW folder, findable through Steam's \"Browse Local Files\". If you are running this in the correct place, please file a bug report.", e.code().value());
+        waitExit("Could not create directory for Bezel and mods. No changes have been made.", ec.value());
     }
 
-    return 0;
+    FILE *outFile = _wfopen(bezelFile.generic_wstring().c_str(), L"wb");
+    fwrite(swfData, 1, swfSize, outFile);
+    fclose(outFile);
+
+    outFile = _wfopen(metadataFile.generic_wstring().c_str(), L"wt");
+    fwrite(metadata.data(), 1, metadata.size(), outFile);
+    fclose(outFile);
+
+    waitExit("Installation succeeded.", 0);
 }

--- a/installer/bezel-swf.s
+++ b/installer/bezel-swf.s
@@ -3,7 +3,7 @@
 .align 4
 
 swfData:
-.incbin "../obj/GemCraft Frostborn Wrath.swf"
+.incbin "../obj/BezelModLoader.swf"
 
 .global swfSize
 .align 4

--- a/src/Bezel/Bezel.as
+++ b/src/Bezel/Bezel.as
@@ -452,6 +452,8 @@ package Bezel
 
 			if (differentCoremods)
 			{
+				this.lattice.apply();
+
 				var file:File = File.applicationStorageDirectory.resolvePath("coremods.bzl");
 				var stream:FileStream = new FileStream();
 				stream.open(file, FileMode.WRITE);
@@ -464,7 +466,6 @@ package Bezel
 					coremod.load(this.lattice);
 				}
 				stream.close();
-				this.lattice.apply();
 			}
 			else
 			{

--- a/src/Bezel/Bezel.as
+++ b/src/Bezel/Bezel.as
@@ -264,8 +264,10 @@ package Bezel
 			{
 				logger.log("Compatibility", "Bezel version is incompatible! Required: " + mod.instance.BEZEL_VERSION);
 				delete mods[mod.instance.MOD_NAME];
+				var name:String = mod.instance.MOD_NAME;
+				var requiredVersion:String = mod.instance.BEZEL_VERSION;
 				mod.unload();
-				throw new Error("Bezel version is incompatible! Bezel: " + VERSION + " while " + mod.instance.MOD_NAME+ " requires " + mod.instance.BEZEL_VERSION);
+				throw new Error("Bezel version is incompatible! Bezel: " + VERSION + " while " + name + " requires " + requiredVersion);
 			}
 			this.addChild(DisplayObject(mod.instance));
 

--- a/src/Bezel/Bezel.as
+++ b/src/Bezel/Bezel.as
@@ -76,10 +76,10 @@ package Bezel
 			
 			this.logger.log("Bezel", "Bezel Mod Loader " + prettyVersion());
 			
-            var swfFile:File = File.applicationDirectory.resolvePath("GemCraft Frostborn Wrath Backup.swf");
+            var swfFile:File = File.applicationDirectory.resolvePath("GemCraft Frostborn Wrath.swf");
 			if (!swfFile.exists)
 			{
-				this.logger.log("Bezel", "Game file not found. Try reinstalling the game, then Bezel.");
+				this.logger.log("Bezel", "Game file not found. Try reinstalling the game.");
 				NativeApplication.nativeApplication.exit(-1);
 			}
 			var tools:File = File.applicationStorageDirectory.resolvePath("Bezel Mod Loader/tools/");

--- a/src/Bezel/Bezel.as
+++ b/src/Bezel/Bezel.as
@@ -452,8 +452,6 @@ package Bezel
 
 			if (differentCoremods)
 			{
-				this.lattice.apply();
-
 				var file:File = File.applicationStorageDirectory.resolvePath("coremods.bzl");
 				var stream:FileStream = new FileStream();
 				stream.open(file, FileMode.WRITE);
@@ -466,6 +464,18 @@ package Bezel
 					coremod.load(this.lattice);
 				}
 				stream.close();
+
+				try {
+					this.lattice.apply();
+				}
+				catch (e:Error)
+				{
+					if (Lattice.moddedSwf.exists)
+					{
+						Lattice.moddedSwf.deleteFile();
+					}
+					throw e;
+				}
 			}
 			else
 			{

--- a/src/Bezel/BezelCoreMod.as
+++ b/src/Bezel/BezelCoreMod.as
@@ -296,12 +296,20 @@ package Bezel
                         for each (var regex:String in matches[index][filepatch])
                         {
                             offset = lattice.findPattern(files[index], offset, new RegExp(regex));
+                            if (offset == -1)
+                            {
+                                throw new Error("Could not apply Bezel coremods");
+                            }
                         }
                         lattice.patchFile(files[index], offset + offsetFromMatches[index][filepatch], replaceNums[index][filepatch], contents[index][filepatch]);
                     }
                     else
                     {
                         offset = lattice.findPattern(files[index], 0, new RegExp(matches[index][filepatch]));
+                        if (offset == -1)
+                        {
+                            throw new Error("Could not apply Bezel coremods");
+                        }
                         lattice.patchFile(files[index], offset + offsetFromMatches[index][filepatch], replaceNums[index][filepatch], contents[index][filepatch]);
                     }
                 }

--- a/src/Bezel/BezelCoreMod.as
+++ b/src/Bezel/BezelCoreMod.as
@@ -285,7 +285,6 @@ package Bezel
 
         internal static function installHooks(lattice:Lattice): void
         {
-            // for in loops loop the indices for some godforsaken reason. Oh well, at least it works
             for (var index:uint = 0; index < files.length; index++)
             {
                 for (var filepatch:uint = 0; filepatch < matches[index].length; filepatch++)
@@ -298,7 +297,7 @@ package Bezel
                             offset = lattice.findPattern(files[index], offset, new RegExp(regex));
                             if (offset == -1)
                             {
-                                throw new Error("Could not apply Bezel coremods");
+                                throw new Error("Could not apply Bezel coremod for " + files[index] + ", patch number " + filepatch);
                             }
                         }
                         lattice.patchFile(files[index], offset + offsetFromMatches[index][filepatch], replaceNums[index][filepatch], contents[index][filepatch]);
@@ -308,7 +307,7 @@ package Bezel
                         offset = lattice.findPattern(files[index], 0, new RegExp(matches[index][filepatch]));
                         if (offset == -1)
                         {
-                            throw new Error("Could not apply Bezel coremods");
+                            throw new Error("Could not apply Bezel coremod for " + files[index] + ", patch number " + filepatch);
                         }
                         lattice.patchFile(files[index], offset + offsetFromMatches[index][filepatch], replaceNums[index][filepatch], contents[index][filepatch]);
                     }

--- a/src/Bezel/Lattice/Lattice.as
+++ b/src/Bezel/Lattice/Lattice.as
@@ -56,7 +56,7 @@ package Bezel.Lattice
 
         private var doneDisassembling:Boolean = false;
 
-        public static var gameSwf:File = File.applicationDirectory.resolvePath("GemCraft Frostborn Wrath Backup.swf");
+        public static var gameSwf:File = File.applicationDirectory.resolvePath("GemCraft Frostborn Wrath.swf");
         public static var moddedSwf:File = File.applicationDirectory.resolvePath("gcfw-modded.swf");
         public static var asm:File = File.applicationStorageDirectory.resolvePath("gcfw.basasm");
         public static var cleanAsm:File = File.applicationStorageDirectory.resolvePath("gcfw-clean.basasm");

--- a/src/Bezel/Lattice/Lattice.as
+++ b/src/Bezel/Lattice/Lattice.as
@@ -344,6 +344,26 @@ package Bezel.Lattice
         }
 
         /**
+         * Copies out code found via a regex within a passed-in GCFW assembly filename
+         * @param filename File to edit. If editing a class, this will be the fully qualified name of the class with periods replaced by /,
+         *                 followed by ".class.asasm". Example: com.giab.games.gcfw.Main becomes "com/giab/games/gcfw/Main.class.asasm"
+         * @param searchFrom Offset at which to start searching the contents. Note that this is zero-indexed: value 1 will search lines 2-end
+         * @param pattern Pattern to search for. Can be a multiline regex
+         * @return The result of pattern.exec
+         */
+        public function retrievePattern(filename:String, searchFrom:int, pattern:RegExp): Object
+        {
+            if (!(filename in this.asasmFiles))
+            {
+                throw new Error("File '" + filename + "' not in disassembly");
+            }
+
+            var searchString:String = this.asasmFiles[filename].split('\n').slice(searchFrom).join('\n');
+
+            return pattern.exec(searchString);
+        }
+
+        /**
          * Copies out code from the passed-in GCFW assembly filename
          * @param filename File to edit. If editing a class, this will be the fully qualified name of the class with periods replaced by /,
          *                 followed by ".class.asasm". Example: com.giab.games.gcfw.Main becomes "com/giab/games/gcfw/Main.class.asasm"

--- a/src/Bezel/Lattice/Lattice.as
+++ b/src/Bezel/Lattice/Lattice.as
@@ -93,6 +93,10 @@ package Bezel.Lattice
             if (e.exitCode != 0)
             {
                 logger.log("toolFinished", currentTool + " failed: " + this.processError);
+				if (coremods.exists)
+				{
+					coremods.deleteFile();
+				}
                 throw new Error("Lattice patch tool " + currentTool + " failed. Check the log file for details");
             }
 

--- a/src/Bezel/Lattice/Lattice.as
+++ b/src/Bezel/Lattice/Lattice.as
@@ -348,6 +348,42 @@ package Bezel.Lattice
         }
 
         /**
+         * Finds and replaces a regex within a passed-in GCFW assembly filename. Note that $ replacement codes can be used in the replacement string.
+         * @param filename File to edit. If editing a class, this will be the fully qualified name of the class with periods replaced by /,
+         *                 followed by ".class.asasm". Example: com.giab.games.gcfw.Main becomes "com/giab/games/gcfw/Main.class.asasm"
+         * @param searchFrom Offset at which to start searching the contents. Note that this is zero-indexed: value 1 will search lines 2-end
+         * @param pattern Pattern to search for. Can be a multiline regex
+         * @param replacement Object to use for replacement string. Passed into the second argument of String.replace
+         * @return Whether the find and replacement succeeded
+         */
+        public function replacePattern(filename:String, searchFrom:int, pattern:RegExp, replacement:*): Boolean
+        {
+            if (!(filename in this.asasmFiles))
+            {
+                throw new Error("File '" + filename + "' not in disassembly");
+            }
+
+            var searchString:String = this.asasmFiles[filename].split('\n').slice(searchFrom).join('\n');
+
+            var line:int = findPattern(filename, searchFrom, pattern);
+            if (line != -1)
+            {
+                var result:Object = pattern.exec(searchString);
+
+                var lines:Array = result[0].split('\n');
+                searchString = searchString.split('\n').slice(0, lines.length).join('\n');
+
+                var replaced:String = searchString.replace(pattern, replacement);
+                
+                this.patchFile(filename, line, lines.length, replaced);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /**
          * Copies out code found via a regex within a passed-in GCFW assembly filename
          * @param filename File to edit. If editing a class, this will be the fully qualified name of the class with periods replaced by /,
          *                 followed by ".class.asasm". Example: com.giab.games.gcfw.Main becomes "com/giab/games/gcfw/Main.class.asasm"


### PR DESCRIPTION
- Adds both retrievePattern and replacePattern.
- Fixes an issue with updated coremods that fail being ignored
- Makes the installer work slightly differently, adding GOG support